### PR TITLE
feat(api): add GET /timesheet/<tid> endpoint and DB wiring via SQLAlchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ env/
 ENV/
 env.bak/
 venv.bak/
+# Python virtual env (hidden)
+.venv/
+**/.venv/
+**/venv/
 
 # Flask
 instance/

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ from config.config import Config
 from controllers.home_controller import home_bp
 from controllers.timesheet_controller import bp_timesheet
 from controllers.pdf_extraction_controller import pdf_extraction_bp
+from controllers.timesheet_query_controller import bp_timesheet_query 
 
 def create_app():
     """Create Flask application"""
@@ -17,6 +18,7 @@ def create_app():
     app.register_blueprint(home_bp)
     app.register_blueprint(bp_timesheet)
     app.register_blueprint(pdf_extraction_bp)
+    app.register_blueprint(bp_timesheet_query)    # GET /timesheet/<tid>
     
     return app
 

--- a/backend/controllers/__init__.py
+++ b/backend/controllers/__init__.py
@@ -1,0 +1,1 @@
+# Controllers package for handling HTTP requests and responses

--- a/backend/controllers/timesheet_query_controller.py
+++ b/backend/controllers/timesheet_query_controller.py
@@ -1,0 +1,33 @@
+from flask import Blueprint, jsonify
+from dao.timesheet_dao import get_metadata_by_tid
+
+bp_timesheet_query = Blueprint("timesheet_query", __name__)
+
+@bp_timesheet_query.get("/timesheet/<int:tid>")
+def get_timesheet_metadata(tid: int):
+    """Return `timesheet.meta_data` as JSON by `tid`.
+
+    Purpose:
+        Read-only endpoint that delegates to the DAO to fetch `meta_data`.
+        Responds with 200 and the JSON when found; otherwise 404.
+
+    Example:
+        # Success:
+        curl -i http://localhost:5001/timesheet/1
+        # -> HTTP/1.0 200 OK
+        # -> {"note":"seed row 1"}
+
+        # Not found:
+        curl -i http://localhost:5001/timesheet/9999
+        # -> HTTP/1.0 404 NOT FOUND
+        # -> {"error":"Timesheet not found"}
+
+    Returns:
+        Flask Response:
+            - 200 OK + application/json (the `meta_data` JSON) if found.
+            - 404 Not Found + {"error": "..."} if no such `tid`.
+    """
+    metadata = get_metadata_by_tid(tid)
+    if metadata is None:
+        return jsonify({"error": "Timesheet not found"}), 404
+    return jsonify(metadata), 200

--- a/backend/dao/__init__.py
+++ b/backend/dao/__init__.py
@@ -1,0 +1,1 @@
+# DAO package for database access

--- a/backend/dao/timesheet_dao.py
+++ b/backend/dao/timesheet_dao.py
@@ -1,0 +1,118 @@
+from typing import Optional, Any, Dict, List
+from sqlalchemy import select
+from persistence.session import SessionLocal
+from models.timesheet_orm import Timesheet
+
+# ---------- helpers ----------
+_DAY_ABBR = {
+    "monday": "Mon",
+    "tuesday": "Tues",   
+    "wednesday": "Wed",
+    "thursday": "Thur",
+    "friday": "Fri",
+    "saturday": "Sat",
+    "sunday": "Sun",
+}
+
+def _hhmm_to_hrs(s: str) -> str:
+    """Convert 'H:MM' (e.g., '7:30') to '7.5hrs'. Empty/zero -> '0hrs'."""
+    if not s or s == "0:00":
+        return "0hrs"
+    try:
+        h, m = s.split(":")
+        val = int(h) + int(m) / 60.0
+        # Pretty formatting: integers like 8.0 -> '8hrs'; otherwise '7.5hrs'
+        return f"{int(val)}hrs" if abs(val - round(val)) < 1e-9 else f"{val:g}hrs"
+    except Exception:
+        # if already like '8hrs' or '7.5hrs', pass through
+        return s if s.endswith("hrs") else f"{s}"
+
+
+def _extract_minimal_payload(meta: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the small 'extracted' dict from the large meta_data JSON."""
+    # employee & PO
+    employee_name = meta.get("employee", {}).get("name", "")
+    po_number = meta.get("base", {}).get("po_number", "")
+
+    # hours by day – prefer totals_row.by_day, fallback to work_entries totals
+    hours: Dict[str, str] = {}
+    by_day = meta.get("totals_row", {}).get("by_day") or {}
+    if by_day:
+        # values like '7:30' -> '7.5hrs'
+        for k, v in by_day.items():
+            hours[k] = _hhmm_to_hrs(v)
+    else:
+        for w in meta.get("work_entries", []) or []:
+            abbr = _DAY_ABBR.get(str(w.get("weekday", "")).lower(), None)
+            if not abbr:
+                continue
+            hhmm = w.get("total_daily_hours", "") or ""
+            hours[abbr] = _hhmm_to_hrs(hhmm)
+
+    # total hours – prefer decimal if present, else convert "H:MM"
+    weekly_total = meta.get("weekly_total", {}) or {}
+    total_hours = None
+    if "total_decimal_hours" in weekly_total:
+        val = weekly_total.get("total_decimal_hours")
+        if isinstance(val, (int, float)):
+            total_hours = f"{val:g}hrs"
+    if not total_hours:
+        total_hours = _hhmm_to_hrs(weekly_total.get("total_hours", "") or "")
+
+    # week range from min/max date_iso in work_entries
+    dates: List[str] = [w.get("date_iso") for w in meta.get("work_entries", []) or [] if w.get("date_iso")]
+    dates = sorted(dates)
+    week_worked = f"{dates[0]}..{dates[-1]}" if dates else ""
+
+    # optional fields if your pipeline fills them
+    additional_text = meta.get("additional_text")  # keep None if missing
+    signatures = meta.get("signatures")           # keep None if missing
+
+    extracted = {
+        "week_worked": week_worked,
+        "hours": hours,
+        "total_hours": total_hours or "0hrs",
+        "employee_name": employee_name,
+        "po_number": po_number,
+    }
+    if signatures is not None:
+        extracted["signatures"] = bool(signatures)
+    if additional_text is not None:
+        extracted["additional_text"] = str(additional_text)
+
+    return extracted
+# ---------- /helpers ----------
+
+
+
+def get_metadata_by_tid(tid: int) -> Optional[Dict[str, Any]]:
+    """Fetch a *small* 'extracted' subset from `timesheet.meta_data`.
+
+    Purpose:
+        Query the `timesheet` row by `tid`, then shrink the large JSON to the
+        fields your validator needs:
+            - week_worked: "YYYY-MM-DD..YYYY-MM-DD"
+            - hours: {"Mon":"8hrs", "Tues":"7.5hrs", ...}
+            - total_hours: "40.5hrs" (or "40hrs")
+            - employee_name, po_number
+            - signatures/additional_text (optional; included only if present)
+
+    Example: >>> get_metadata_by_tid(1)
+        {'week_worked': '2025-08-11..2025-08-17', 'hours': {'Mon': '7.5hrs', ...}, ...}
+
+    Returns:
+        Optional[Dict[str, Any]]: The minimal 'extracted' dict, or None if not found.
+    """
+    with SessionLocal() as session:
+        meta: Optional[Dict[str, Any]] = session.execute(
+            select(Timesheet.meta_data).where(Timesheet.tid == tid)
+        ).scalar_one_or_none()
+
+    if meta is None:
+        return None
+
+    return _extract_minimal_payload(meta)
+    
+    
+
+

--- a/backend/models/timesheet_orm.py
+++ b/backend/models/timesheet_orm.py
@@ -1,0 +1,47 @@
+"""ORM mapping for the 'timesheet' table.
+
+This mapping mirrors db/init_tables.sql:
+    - tid SERIAL PRIMARY KEY
+    - meta_data JSONB
+    - created_at TIMESTAMPTZ DEFAULT now()
+    - status TEXT
+"""
+from sqlalchemy import Column, Integer, DateTime, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+from persistence.session import Base
+
+class Timesheet(Base):
+    """Timesheet ORM model.
+
+    Purpose:
+        Map the PostgreSQL `timesheet` table to a Python class so that the app
+        can query it via SQLAlchemy ORM.
+
+    Example:
+        >>> from sqlalchemy import select
+        >>> from persistence.session import SessionLocal
+        >>> from models.timesheet_orm import Timesheet
+        >>> with SessionLocal() as s:
+        ...     row = s.execute(
+        ...         select(Timesheet.meta_data).where(Timesheet.tid == 1)
+        ...     ).first()
+        ...     data = row[0] if row else None  # JSON dict or None
+
+    Returns:
+        This class itself does not return values. Using it in a query returns
+        rows/columns (e.g., a JSON dict for `meta_data`) or ORM instances.
+    """
+    __tablename__ = "timesheet"
+
+    # init_tables.sql: tid SERIAL PRIMARY KEY  -> Integer + autoincrement
+    tid = Column(Integer, primary_key=True, autoincrement=True)
+
+    # init_tables.sql: meta_data JSONB（not declared NOT NULL）→ nullable=True
+    meta_data = Column(JSONB, nullable=True)
+
+    # init_tables.sql: created_at TIMESTAMPTZ DEFAULT now()
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=True)
+
+    # init_tables.sql: status TEXT（not declared default/not null）
+    status = Column(String, nullable=True)

--- a/backend/persistence/__init__.py
+++ b/backend/persistence/__init__.py
@@ -1,0 +1,1 @@
+# Persistence package for database session management

--- a/backend/persistence/session.py
+++ b/backend/persistence/session.py
@@ -1,0 +1,32 @@
+"""Database engine and session factory.
+
+Purpose:
+    Provide a single SQLAlchemy `engine`, a session factory `SessionLocal`,
+    and the ORM base class `Base` for the application. This module handles
+    connection setup only. Schema creation and seed data are handled by
+    /db/init_tables.sql (invoked by start.sh).
+"""
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from config.config import Config
+
+# Fallback to SQLite only for local testing when DATABASE_URL is not provided.
+DATABASE_URL = Config.DATABASE_URL or "sqlite:///easyx.db"
+
+# Global Engine (pool_pre_ping guards against stale connections).
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,   # Automatic disconnection detection
+    future=True
+)
+
+# Session factory. Use: `with SessionLocal() as session: ...
+SessionLocal = sessionmaker(
+    bind=engine,
+    autocommit=False,
+    autoflush=False,
+    future=True
+)
+
+# ORM mapping base. Do NOT call Base.metadata.create_all() in the app.
+Base = declarative_base()


### PR DESCRIPTION
### Summary

Add a read-only Timesheet query API backed by PostgreSQL via SQLAlchemy.

- New endpoint: GET /timesheet/<tid>
- Returns a minimal extracted subset of timesheet.meta_data:
     - week_worked, hours (per weekday), total_hours, employee_name, po_number
- Introduces a lightweight persistence layer (engine, SessionLocal, Base) and an ORM mapping for the timesheet table.

This PR wires the backend to the database (no schema changes; table is created/seeded by db/init_tables.sql).


### Config & Setup

Requires environment variable DATABASE_URL (example for local dev):
postgresql+psycopg2:///easyxdb

Database/table/data are created by running db/init_tables.sql.
(Our start.sh will handle this in CI/Prod; for local testing we inserted one example row.)
No migrations are introduced by this PR.